### PR TITLE
Add reuse field to options argument of render()

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -100,8 +100,8 @@ export const renderDefaultOptions: RenderOptionsInterface = deepFreeze({
  * Main function
  */
 
-export const render = createPluginGenerator(
-    (opts = {}) => (files, metalsmith, done) => {
+export const render = createPluginGenerator((opts = {}) => {
+    return (files, metalsmith, done) => {
         const options = normalizeRenderOptions(
             metalsmith,
             opts,
@@ -130,6 +130,5 @@ export const render = createPluginGenerator(
         });
 
         done(null, files, metalsmith);
-    },
-    renderDefaultOptions,
-);
+    };
+}, renderDefaultOptions);

--- a/src/render.ts
+++ b/src/render.ts
@@ -42,8 +42,8 @@ const previousRenderOptionsMap: WeakMap<
 
 export function normalizeRenderOptions(
     metalsmith: Metalsmith,
-    options: Partial<RenderOptionsInterface>,
     defaultOptions: RenderOptionsInterface,
+    options: Partial<RenderOptionsInterface>,
 ): RenderOptionsInterface {
     debugOptions('normalizing options: %o', options);
 
@@ -117,8 +117,8 @@ export const render = createPluginGenerator((opts = {}) => {
     return (files, metalsmith, done) => {
         const options = normalizeRenderOptions(
             metalsmith,
-            opts,
             renderDefaultOptions,
+            opts,
         );
 
         getMatchedFiles(files, options.pattern).forEach(filename => {

--- a/src/render.ts
+++ b/src/render.ts
@@ -34,6 +34,25 @@ export interface RenderOptionsInterface {
  * Utility functions
  */
 
+let previousRenderOptions: Partial<RenderOptionsInterface> | undefined;
+
+export function normalizeRenderOptions(
+    options: Partial<RenderOptionsInterface>,
+    defaultOptions: RenderOptionsInterface,
+): RenderOptionsInterface {
+    const mergedOptions = { ...defaultOptions, ...options };
+    const partialOptions = mergedOptions.reuse
+        ? { ...previousRenderOptions, ...options }
+        : options;
+
+    previousRenderOptions = partialOptions;
+
+    return {
+        ...defaultOptions,
+        ...partialOptions,
+    };
+}
+
 export function getRenderOptions<T extends RenderOptionsInterface>(
     options: T,
 ): RenderOptionsInterface & {
@@ -79,10 +98,7 @@ export const renderDefaultOptions: RenderOptionsInterface = deepFreeze({
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const render: RenderFuncInterface = function(opts = {}) {
-    const options = {
-        ...renderDefaultOptions,
-        ...opts,
-    };
+    const options = normalizeRenderOptions(opts, renderDefaultOptions);
 
     return createEachPlugin((filename, files, metalsmith) => {
         const data: unknown = files[filename];

--- a/src/render.ts
+++ b/src/render.ts
@@ -27,6 +27,7 @@ export interface RenderOptionsInterface {
     locals: pug.LocalsObject;
     useMetadata: boolean;
     pattern: string | string[];
+    reuse: boolean;
 }
 
 /*
@@ -38,8 +39,8 @@ export function getRenderOptions<T extends RenderOptionsInterface>(
 ): RenderOptionsInterface & {
     otherOptions: Omit<T, keyof RenderOptionsInterface>;
 } {
-    const { locals, useMetadata, pattern, ...otherOptions } = options;
-    return { locals, useMetadata, pattern, otherOptions };
+    const { locals, useMetadata, pattern, reuse, ...otherOptions } = options;
+    return { locals, useMetadata, pattern, reuse, otherOptions };
 }
 
 export function getRenderedText(
@@ -69,6 +70,7 @@ export const renderDefaultOptions: RenderOptionsInterface = deepFreeze({
     locals: {},
     useMetadata: false,
     pattern: ['**/*'],
+    reuse: false,
 });
 
 /*

--- a/src/render.ts
+++ b/src/render.ts
@@ -100,8 +100,8 @@ export const renderDefaultOptions: RenderOptionsInterface = deepFreeze({
  * Main function
  */
 
-export const render = createPluginGenerator((opts = {}) => {
-    return (files, metalsmith, done) => {
+export const render = createPluginGenerator(
+    (opts = {}) => (files, metalsmith, done) => {
         const options = normalizeRenderOptions(
             metalsmith,
             opts,
@@ -130,5 +130,6 @@ export const render = createPluginGenerator((opts = {}) => {
         });
 
         done(null, files, metalsmith);
-    };
-}, renderDefaultOptions);
+    },
+    renderDefaultOptions,
+);

--- a/src/render.ts
+++ b/src/render.ts
@@ -14,6 +14,7 @@ import {
 import { DeepReadonly } from './utils/types';
 
 const debug = createDebug('metalsmith-pug-extra:render');
+const debugOptions = debug.extend('options');
 
 /*
  * Interfaces
@@ -44,17 +45,29 @@ export function normalizeRenderOptions(
     options: Partial<RenderOptionsInterface>,
     defaultOptions: RenderOptionsInterface,
 ): RenderOptionsInterface {
-    const mergedOptions = { ...defaultOptions, ...options };
-    const partialOptions = mergedOptions.reuse
-        ? { ...previousRenderOptionsMap.get(metalsmith), ...options }
-        : options;
+    debugOptions('normalizing options: %o', options);
 
+    const partialOptions = {};
+    const mergedOptions = { ...defaultOptions, ...options };
+
+    if (mergedOptions.reuse && previousRenderOptionsMap.has(metalsmith)) {
+        const previousRenderOptions = previousRenderOptionsMap.get(metalsmith);
+        debugOptions('reuse previous options: %o', previousRenderOptions);
+        Object.assign(partialOptions, previousRenderOptions);
+    }
+
+    Object.assign(partialOptions, options);
+
+    debugOptions('save current options: %o', partialOptions);
     previousRenderOptionsMap.set(metalsmith, partialOptions);
 
-    return {
+    const normalizedOptions = {
         ...defaultOptions,
         ...partialOptions,
     };
+    debugOptions('normalized options: %o', normalizedOptions);
+
+    return normalizedOptions;
 }
 
 export function getRenderOptions<T extends RenderOptionsInterface>(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -76,6 +76,20 @@ export function addFile(
     return newFile;
 }
 
+export function getMatchedFiles(
+    files: Metalsmith.Files,
+    pattern: DeepReadonly<string | string[] | undefined>,
+): string[] {
+    const matchPatterns = (Array.isArray as isReadonlyOrWritableArray)(pattern)
+        ? [...pattern]
+        : pattern;
+    const matchedFiles =
+        matchPatterns !== undefined
+            ? match(Object.keys(files), matchPatterns)
+            : Object.keys(files);
+    return matchedFiles;
+}
+
 export function createEachPlugin(
     callback: (
         filename: string,
@@ -84,14 +98,8 @@ export function createEachPlugin(
     ) => void | Promise<void>,
     pattern?: DeepReadonly<string | string[]>,
 ): Metalsmith.Plugin {
-    const matchPatterns = (Array.isArray as isReadonlyOrWritableArray)(pattern)
-        ? [...pattern]
-        : pattern;
     return (files, metalsmith, done) => {
-        const matchedFiles: string[] =
-            matchPatterns !== undefined
-                ? match(Object.keys(files), matchPatterns)
-                : Object.keys(files);
+        const matchedFiles = getMatchedFiles(files, pattern);
 
         Promise.all(
             matchedFiles.map(filename => callback(filename, files, metalsmith)),

--- a/test/fixtures/always-different/now.pug
+++ b/test/fixtures/always-different/now.pug
@@ -3,18 +3,32 @@
     return String(num).padStart(length, '0');
   }
 
-  const now = new Date();
+  function dateEquals(date1, date2) {
+    return date1.getTime() === date2.getTime();
+  }
 
-  // https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#valid-month-string
-  const monthString = `${padNum(now.getFullYear(), 4)}-${padNum(now.getMonth() + 1)}`;
+  function date2localDateTimeString(date) {
+    // https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#valid-month-string
+    const monthString = `${padNum(date.getFullYear(), 4)}-${padNum(date.getMonth() + 1)}`;
 
-  // https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#valid-date-string
-  const dateString = `${monthString}-${padNum(now.getDate())}`;
+    // https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#valid-date-string
+    const dateString = `${monthString}-${padNum(date.getDate())}`;
 
-  // https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#valid-time-string
-  const timeString = `${padNum(now.getHours())}:${padNum(now.getMinutes())}:${padNum(now.getSeconds())}:${padNum(now.getMilliseconds(), 3)}`;
+    // https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#valid-time-string
+    const timeString = `${padNum(date.getHours())}:${padNum(date.getMinutes())}:${padNum(date.getSeconds())}:${padNum(date.getMilliseconds(), 3)}`;
 
-  // https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#valid-local-date-and-time-string
-  const localDateAndTimeString = `${dateString}T${timeString}`;
+    // https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#valid-local-date-and-time-string
+    const localDateAndTimeString = `${dateString}T${timeString}`;
 
-time= localDateAndTimeString
+    return localDateAndTimeString;
+  }
+
+- const date1 = new Date();
+time= date2localDateTimeString(date1)
+
+-
+  let date2;
+  do {
+    date2 = new Date();
+  } while (dateEquals(date1, date2));
+time= date2localDateTimeString(date2)

--- a/test/fixtures/always-different/now.pug
+++ b/test/fixtures/always-different/now.pug
@@ -1,0 +1,20 @@
+-
+  function padNum(num, length=2) {
+    return String(num).padStart(length, '0');
+  }
+
+  const now = new Date();
+
+  // https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#valid-month-string
+  const monthString = `${padNum(now.getFullYear(), 4)}-${padNum(now.getMonth() + 1)}`;
+
+  // https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#valid-date-string
+  const dateString = `${monthString}-${padNum(now.getDate())}`;
+
+  // https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#valid-time-string
+  const timeString = `${padNum(now.getHours())}:${padNum(now.getMinutes())}:${padNum(now.getSeconds())}:${padNum(now.getMilliseconds(), 3)}`;
+
+  // https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#valid-local-date-and-time-string
+  const localDateAndTimeString = `${dateString}T${timeString}`;
+
+time= localDateAndTimeString

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -5,7 +5,7 @@ import path from 'path';
 import slug from 'slug';
 import util from 'util';
 
-import { isObject } from '../../src/utils';
+import { isFile, isObject } from '../../src/utils';
 
 const TEST_DIR_PATH = path.resolve(__dirname, '..');
 
@@ -85,6 +85,27 @@ export async function readSourceFile(
     const readFile = util.promisify(fs.readFile);
     const sourceFilepath = metalsmith.path(metalsmith.source(), filename);
     return (await readFile(sourceFilepath)).toString();
+}
+
+export function getFileContentsPlugin(
+    filename: string,
+    callback: (contents: string | undefined) => void,
+): Metalsmith.Plugin {
+    return (files, metalsmith, done) => {
+        const targetFileData = files[filename];
+
+        if (targetFileData === undefined) {
+            throw ReferenceError(`not found in metalsmith/files: ${filename}`);
+        }
+
+        if (isFile(targetFileData)) {
+            callback(targetFileData.contents.toString());
+        } else {
+            callback(undefined);
+        }
+
+        done(null, files, metalsmith);
+    };
 }
 
 export function setLocalsPlugin(locals: {

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -9,6 +9,10 @@ import { isFile, isObject } from '../../src/utils';
 
 const TEST_DIR_PATH = path.resolve(__dirname, '..');
 
+export function sleep(sec: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, sec * 1000));
+}
+
 export function ignoreTypeError(callback: () => void): void {
     try {
         callback();
@@ -35,18 +39,20 @@ export function objIgnoreKeys<T>(obj: T, keyList: string[]): T {
 }
 
 const destDirSet = new Set();
-export function getDestDir(t: ExecutionContext): string {
+export function getDestDir(t: ExecutionContext, namespace?: string): string {
     const dirName = slug(t.title, slug.defaults.modes['rfc3986']);
-    if (destDirSet.has(dirName)) {
-        throw new Error(`Duplicate test dir: ${dirName}`);
+    const dirpath = namespace ? path.join(dirName, namespace) : dirName;
+    if (destDirSet.has(dirpath)) {
+        throw new Error(`Duplicate test dir: ${dirpath}`);
     }
-    destDirSet.add(dirName);
-    return dirName;
+    destDirSet.add(dirpath);
+    return dirpath;
 }
 
 export function createMetalsmith(
     t: ExecutionContext,
     destNamespace?: string,
+    subNamespace?: string,
 ): Metalsmith {
     return Metalsmith(path.join(TEST_DIR_PATH, 'fixtures'))
         .source('pages')
@@ -54,7 +60,7 @@ export function createMetalsmith(
             path.join(
                 'build',
                 ...(destNamespace ? [destNamespace] : []),
-                getDestDir(t),
+                getDestDir(t, subNamespace),
             ),
         )
         .clean(true);
@@ -62,12 +68,12 @@ export function createMetalsmith(
 
 export function generateMetalsmithCreator(
     testFilepath: string,
-): (t: ExecutionContext) => Metalsmith {
+): (t: ExecutionContext, subNamespace?: string) => Metalsmith {
     const namespace = path
         .relative(TEST_DIR_PATH, path.resolve(testFilepath))
         .replace(/\.(?:js|ts)$/, '');
-    return (t: ExecutionContext) => {
-        return createMetalsmith(t, namespace);
+    return (t, subNamespace) => {
+        return createMetalsmith(t, namespace, subNamespace);
     };
 }
 
@@ -89,22 +95,26 @@ export async function readSourceFile(
 
 export function getFileContentsPlugin(
     filename: string,
-    callback: (contents: string | undefined) => void,
+    callback: (contents: string | undefined) => void | Promise<void>,
 ): Metalsmith.Plugin {
     return (files, metalsmith, done) => {
-        const targetFileData = files[filename];
+        (async () => {
+            const targetFileData = files[filename];
 
-        if (targetFileData === undefined) {
-            throw ReferenceError(`not found in metalsmith/files: ${filename}`);
-        }
+            if (targetFileData === undefined) {
+                throw ReferenceError(
+                    `not found in metalsmith/files: ${filename}`,
+                );
+            }
 
-        if (isFile(targetFileData)) {
-            callback(targetFileData.contents.toString());
-        } else {
-            callback(undefined);
-        }
+            if (isFile(targetFileData)) {
+                await callback(targetFileData.contents.toString());
+            } else {
+                await callback(undefined);
+            }
 
-        done(null, files, metalsmith);
+            done(null, files, metalsmith);
+        })();
     };
 }
 


### PR DESCRIPTION
Adds the logic to reuse the arguments of the render() function.
This feature is inspired by the https://github.com/sounisi5011/metalsmith-pug-extra/issues/25#issuecomment-502724939.
