### PR TITLE
Move "@types/*" packages not included in generated type definitions from "dependencies" to "devDependencies"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,20 @@
 * `lint-staged`
     * [#71] - `9.2.0` -> `9.2.1`
 
+### Added Dependencies
+
+#### devDependencies
+
+* [#74] - `cross-spawn@6.0.5`
+
+### Moved Dependencies
+
+#### dependencies -> devDependencies
+
+* [#74] - `@types/debug@4.1.4`
+* [#74] - `@types/deep-freeze-strict@1.1.0`
+* [#74] - `@types/lodash.clonedeep@4.5.6`
+
 ### Removed Dependencies
 
 #### dependencies
@@ -40,6 +54,7 @@
 [#71]: https://github.com/sounisi5011/metalsmith-pug-extra/pull/71
 [#72]: https://github.com/sounisi5011/metalsmith-pug-extra/pull/72
 [#73]: https://github.com/sounisi5011/metalsmith-pug-extra/pull/73
+[#74]: https://github.com/sounisi5011/metalsmith-pug-extra/pull/74
 
 ## [1.1.1] (2019-07-15)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -484,12 +484,14 @@
     "@types/debug": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.4.tgz",
-      "integrity": "sha512-D9MyoQFI7iP5VdpEyPZyjjqIJ8Y8EDNQFIFVLOmeg1rI1xiHOChyUPMPRUVfqFCerxfE+yS3vMyj37F6IdtOoQ=="
+      "integrity": "sha512-D9MyoQFI7iP5VdpEyPZyjjqIJ8Y8EDNQFIFVLOmeg1rI1xiHOChyUPMPRUVfqFCerxfE+yS3vMyj37F6IdtOoQ==",
+      "dev": true
     },
     "@types/deep-freeze-strict": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@types/deep-freeze-strict/-/deep-freeze-strict-1.1.0.tgz",
-      "integrity": "sha1-RHpqJXYZE0SqQjEBMd099cQUksQ="
+      "integrity": "sha1-RHpqJXYZE0SqQjEBMd099cQUksQ=",
+      "dev": true
     },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
@@ -523,12 +525,14 @@
     "@types/lodash": {
       "version": "4.14.136",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.136.tgz",
-      "integrity": "sha512-0GJhzBdvsW2RUccNHOBkabI8HZVdOXmXbXhuKlDEd5Vv12P7oAVGfomGp3Ne21o5D/qu1WmthlNKFaoZJJeErA=="
+      "integrity": "sha512-0GJhzBdvsW2RUccNHOBkabI8HZVdOXmXbXhuKlDEd5Vv12P7oAVGfomGp3Ne21o5D/qu1WmthlNKFaoZJJeErA==",
+      "dev": true
     },
     "@types/lodash.clonedeep": {
       "version": "4.5.6",
       "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz",
       "integrity": "sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==",
+      "dev": true,
       "requires": {
         "@types/lodash": "*"
       }
@@ -1778,14 +1782,24 @@
       }
     },
     "cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "requires": {
-        "lru-cache": "^4.0.1",
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
       }
     },
     "crypto-random-string": {
@@ -2662,6 +2676,19 @@
         "p-finally": "^1.0.0",
         "signal-exit": "^3.0.0",
         "strip-eof": "^1.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        }
       }
     },
     "extend-shallow": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "release:validation:publishable": "can-npm-publish --verbose",
     "test": "run-s test:peer-deps lint test:ava test:check-type-defs-pkgs",
     "test:ava": "ava",
-    "test:check-type-defs-pkgs": "node script/check-type-defs-pkgs.js ./dist/",
+    "test:check-type-defs-pkgs": "node script/check-type-defs-pkgs.js ./dist/ build",
     "test:peer-deps": "check-peer-deps"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -48,8 +48,9 @@
     "release:validation:git-branch": "git-branch-is master",
     "release:validation:git-work-dir": "is-git-status-clean",
     "release:validation:publishable": "can-npm-publish --verbose",
-    "test": "run-s test:peer-deps lint test:ava",
+    "test": "run-s test:peer-deps lint test:ava test:check-type-defs-pkgs",
     "test:ava": "ava",
+    "test:check-type-defs-pkgs": "node script/check-type-defs-pkgs.js ./dist/",
     "test:peer-deps": "check-peer-deps"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -73,9 +73,6 @@
     ]
   },
   "dependencies": {
-    "@types/debug": "4.1.4",
-    "@types/deep-freeze-strict": "1.1.0",
-    "@types/lodash.clonedeep": "4.5.6",
     "@types/metalsmith": "2.3.0",
     "@types/pug": "2.0.4",
     "debug": "4.1.1",
@@ -87,6 +84,9 @@
   },
   "devDependencies": {
     "@sounisi5011/check-peer-deps": "sounisi5011/check-peer-deps",
+    "@types/debug": "4.1.4",
+    "@types/deep-freeze-strict": "1.1.0",
+    "@types/lodash.clonedeep": "4.5.6",
     "@types/node": "*",
     "@types/sinon": "7.0.13",
     "@types/slug": "0.9.1",

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "@typescript-eslint/parser": "1.13.0",
     "ava": "2.2.0",
     "can-npm-publish": "1.3.1",
+    "cross-spawn": "6.0.5",
     "del-cli": "2.0.0",
     "eslint": "5.16.0",
     "eslint-config-prettier": "6.0.0",

--- a/script/check-type-defs-pkgs.js
+++ b/script/check-type-defs-pkgs.js
@@ -1,0 +1,101 @@
+const fs = require('fs');
+const path = require('path');
+const util = require('util');
+
+const parser = require('@typescript-eslint/typescript-estree');
+const recursive = require('recursive-readdir');
+
+const PKG = require(path.resolve(process.cwd(), 'package.json'));
+const AST_IMPORT_TYPES = Object.entries(parser.AST_NODE_TYPES)
+  .filter(([key]) => /import/i.test(key))
+  .map(([, value]) => value);
+
+const readFileAsync = util.promisify(fs.readFile);
+
+async function main(distDir) {
+  const distDirpath = path.resolve(process.cwd(), distDir);
+
+  const tsFilepathList = (
+    (await recursive(distDirpath))
+      .filter(path => /\.ts$/.test(path))
+  );
+
+  if (tsFilepathList.length < 1) {
+    throw new Error(`".ts" file does not exist in "${distDir}" directory`);
+  }
+
+  const importSet = new Set(
+    (await Promise.all(
+      tsFilepathList
+        .map(filepath => readFileAsync(filepath, 'utf8'))
+        .map(async (code) => parser.parse(await code))
+        .map(async (ast) => getImportNames(await ast))
+    ))
+      .reduce((a, b) => a.concat(b))
+  );
+
+  const typePkgNames = {
+    deps: (
+      Object.keys(PKG.dependencies)
+        .filter(pkgName => /^@types\//.test(pkgName))
+        .filter(typePkgName => !importSet.has(typePkgName.replace(/^@types\//, '')))
+    ),
+    devDeps: [],
+  };
+  importSet.forEach(name => {
+    const typePkgName = `@types/${name}`;
+    if (typePkgName in PKG.devDependencies) {
+      typePkgNames.devDeps.push(typePkgName);
+    }
+  });
+
+  if (0 < typePkgNames.deps.length) {
+    const pkgNamesStr = typePkgNames.deps.map(pkgName => `* ${pkgName}`).join('\n');
+    console.log(`Some packages do not need to be listed in the "dependencies" field:\n${pkgNamesStr}`);
+  }
+
+  if (0 < typePkgNames.devDeps.length) {
+    const pkgNamesStr = typePkgNames.devDeps.map(pkgName => `* ${pkgName}`).join('\n');
+    throw new Error(`Some packages need to be listed in the "dependencies" field:\n${pkgNamesStr}`);
+  }
+}
+
+function getImportNames(ast) {
+  if (Array.isArray(ast)) {
+    return [].concat(...ast.map(getImportNames));
+  } else if (typeof ast === 'object' && ast) {
+    if (ast.type && AST_IMPORT_TYPES.includes(ast.type)) {
+      if (ast.type === 'ImportDeclaration') {
+        if (ast.source.type === 'Literal') {
+          return [ast.source.value];
+        }
+        throw new TypeError(`AST type "${ast.type}" / Source AST type "${ast.source.type}" not supported`);
+      }
+
+      if (ast.type === 'TSImportType') {
+        if (ast.parameter.type === 'TSLiteralType') {
+          if (ast.parameter.literal.type === 'Literal') {
+            return [ast.parameter.literal.value];
+          }
+          throw new TypeError(`AST type "${ast.type}" / Parameter AST type "${ast.parameter.type}" / Literal AST type "${ast.parameter.literal.type}" not supported`);
+        }
+        throw new TypeError(`AST type "${ast.type}" / Parameter AST type "${ast.parameter.type}" not supported`);
+      }
+
+      throw new TypeError(`AST type "${ast.type}" not supported`);
+    } else {
+      return [].concat(...Object.values(ast).map(getImportNames));
+    }
+  }
+
+  return [];
+}
+
+(async () => {
+  try {
+    await main(process.argv[2]);
+  } catch (err) {
+    process.exitCode = 1;
+    console.error(err);
+  }
+})();

--- a/script/check-type-defs-pkgs.js
+++ b/script/check-type-defs-pkgs.js
@@ -1,4 +1,4 @@
-const { spawn } = require('child_process');
+const spawn = require('cross-spawn');
 const fs = require('fs');
 const path = require('path');
 const util = require('util');


### PR DESCRIPTION
Some packages are not included in the generated type definition files.
Because such packages are not used, it is preferable to specify `devDependencies` instead of `dependencies`.
